### PR TITLE
Revamp README with modern personal branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,46 @@
-<div align="center">
-  <h1 style="font-size:3.5rem; font-weight:800; margin-bottom:0;">✨ Hey, I'm <span style="color:#7f5af0;">Amir</span></h1>
-  <p style="font-size:1.2rem; color:#94a1b2; margin-top:0.5rem;">
-    Full‑stack explorer crafting experiences across every layer — currently shipping with Flutter, FastAPI & React.
+<div align="center" style="font-family:'Inter', sans-serif;">
+  <h1 style="font-size:3.25rem; font-weight:800; margin-bottom:0.25rem;">Hey, I'm <span style="color:#7f5af0;">Amir</span></h1>
+  <p style="font-size:1.15rem; color:#94a1b2; max-width:640px;">
+    Arch user, full-stack tinkerer, and fan of shipping polished ideas. These days I'm weaving Flutter experiences,
+    composing FastAPI backends, and shaping React frontends—while staying curious about every other stack I can touch.
   </p>
   <img src="https://img.shields.io/badge/arch%20btw-0f172a?style=for-the-badge&logo=archlinux&logoColor=7dd3fc" alt="Arch BTW" />
 </div>
 
----
+<br />
 
-## 🌈 Tech Palette
+<div align="center">
+  <table>
+    <tr>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api?username=amir&show_icons=true&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6&icon_color=7f5af0" alt="GitHub Stats" />
+      </td>
+      <td>
+        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=amir&layout=compact&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6" alt="Top Languages" />
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2" align="center">
+        <img src="https://streak-stats.demolab.com?user=amir&theme=dark&hide_border=true&background=0D1117&ring=7f5af0&fire=7f5af0&currStreakLabel=ffffff" alt="GitHub Streak" />
+      </td>
+    </tr>
+  </table>
+</div>
 
-| Layer | Favourites | Vibe |
-| :--- | :--- | :--- |
-| Mobile Magic | <img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter" /> | Smooth animations & pixel-perfect UIs |
-| Web Canvas | <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" /> | Component-driven storytelling |
-| API Wizardry | <img src="https://img.shields.io/badge/FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white" alt="FastAPI" /> | Fast, clean, async-first backends |
-| ...and beyond | Every stack I can get my hands on | Infinite curiosity ✨ |
+<br />
 
----
+<div align="center" style="max-width:780px; font-size:1.05rem; color:#94a1b2; line-height:1.65;">
+  <p>
+    I obsess over meaningful UX flows, resilient API design, and the craft of developer experience. Whether it's pairing Flutter animations
+    with real-time FastAPI services or iterating on React-driven design systems, I'm chasing work that feels cohesive, thoughtful, and fun.
+  </p>
+  <p>
+    Beyond shipping features, I'm steadily documenting patterns, refining tooling, and learning from every stack I encounter. If there's a way
+    to make the build pipeline smoother or the interface kinder, I'm there for it.
+  </p>
+</div>
 
-## 🧭 Current Focus
-
-- 🎯 Building hybrid apps that feel native everywhere.
-- ⚡️ Experimenting with real-time experiences & delightful micro-interactions.
-- 🛠️ Designing APIs that feel like products.
-- 🧪 Constantly iterating on developer experience — because great DX powers great UX.
-
----
-
-## 📌 Featured Highlights
-
-> A snapshot of things that make me excited to open the editor.
-
-- **Flow-first architecture** – Orchestrating frontends with state machines for clarity and resilience.
-- **Design systems nerd** – Crafting reusable component libraries, accessible color palettes, and motion guides.
-- **Cloud-native mindset** – Deploying with confidence using containerized, automated pipelines.
-
----
-
-## ☕ Let's Connect
+<br />
 
 <div align="center">
   <a href="mailto:hello@amir.dev"><img src="https://img.shields.io/badge/Email-ff6b6b?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
@@ -46,6 +48,8 @@
   <a href="https://github.com/amir"><img src="https://img.shields.io/badge/GitHub-161B22?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
 </div>
 
----
+<br />
 
-<sub align="center">“Code is just creative energy in motion.” — Amir</sub>
+<div align="center" style="font-size:0.9rem; color:#7f5af0;">
+  <em>"Code is just creative energy in motion." — Amir</em>
+</div>

--- a/README.md
+++ b/README.md
@@ -1,55 +1,90 @@
-<div align="center" style="font-family:'Inter', sans-serif;">
-  <h1 style="font-size:3.25rem; font-weight:800; margin-bottom:0.25rem;">Hey, I'm <span style="color:#7f5af0;">Amir</span></h1>
-  <p style="font-size:1.15rem; color:#94a1b2; max-width:640px;">
-    Arch user, full-stack tinkerer, and fan of shipping polished ideas. These days I'm weaving Flutter experiences,
-    composing FastAPI backends, and shaping React frontends—while staying curious about every other stack I can touch.
-  </p>
-  <img src="https://img.shields.io/badge/arch%20btw-0f172a?style=for-the-badge&logo=archlinux&logoColor=7dd3fc" alt="Arch BTW" />
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:7f5af0,100:2cb6f6&height=220&section=header&text=Hey%2C%20I'm%20Amir&fontSize=54&fontColor=ffffff&fontAlign=50&fontAlignY=35&desc=Arch%20Linux%20user%20%7C%20Full-stack%20craftsman&descAlign=50&descAlignY=60" alt="Amir header" />
+</p>
+
+<p align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=22&pause=1400&color=7F5AF0&center=true&vCenter=true&width=600&lines=I+use+Arch%2C+btw.;Flutter+%2B+FastAPI+%2B+React+in+flow.;Restless+about+every+other+stack+too." alt="Typing intro" />
+</p>
+
+<p align="center" style="max-width:760px; margin: 0 auto; font-family:'Inter',sans-serif; color:#94a1b2; font-size:1.05rem; line-height:1.8;">
+  I'm a product-minded engineer who keeps the pipeline elegant and the interface delightful. Whether I'm animating Flutter
+  micro-interactions, crafting resilient FastAPI services, or steering React-driven systems, I care about the whole experience—
+  from architecture to polish.
+</p>
+
+<br />
+
+<div align="center" style="display:grid; gap:16px; max-width:860px; margin:0 auto;">
+  <img src="https://github-readme-stats.vercel.app/api?username=amir&show_icons=true&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6&icon_color=2cb6f6" alt="GitHub stats" style="border-radius:18px;" />
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=amir&layout=compact&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6" alt="Top languages" style="border-radius:18px;" />
 </div>
 
 <br />
 
-<div align="center">
-  <table>
-    <tr>
-      <td>
-        <img src="https://github-readme-stats.vercel.app/api?username=amir&show_icons=true&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6&icon_color=7f5af0" alt="GitHub Stats" />
-      </td>
-      <td>
-        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=amir&layout=compact&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6" alt="Top Languages" />
-      </td>
-    </tr>
-    <tr>
-      <td colspan="2" align="center">
-        <img src="https://streak-stats.demolab.com?user=amir&theme=dark&hide_border=true&background=0D1117&ring=7f5af0&fire=7f5af0&currStreakLabel=ffffff" alt="GitHub Streak" />
-      </td>
-    </tr>
-  </table>
+<div align="center" style="max-width:860px; margin:0 auto; display:grid; gap:20px; font-family:'Inter',sans-serif;">
+  <div style="background:linear-gradient(135deg,rgba(127,90,240,0.16),rgba(44,182,246,0.12)); padding:26px 28px; border-radius:18px; border:1px solid rgba(148,161,178,0.15); backdrop-filter:blur(18px);">
+    <h3 style="margin:0 0 14px; color:#f8f9ff; font-size:1.4rem;">Stacks in heavy rotation</h3>
+    <p style="margin:0; color:#94a1b2; line-height:1.7;">
+      Flutter for buttery motion and native feel, FastAPI for confident, type-hinted services, React for immersive web apps.
+      I'm still sampling every stack I can get my hands on, but these three are on repeat right now.
+    </p>
+    <p style="margin:16px 0 0;">
+      <img src="https://skillicons.dev/icons?i=flutter,fastapi,react,ts,python,dart" alt="Tech icons" />
+    </p>
+  </div>
+
+  <div style="display:grid; gap:16px;">
+    <div style="background:rgba(13,17,23,0.8); padding:22px 24px; border-radius:16px; border:1px solid rgba(148,161,178,0.14);">
+      <h4 style="margin:0 0 10px; color:#f8f9ff; font-size:1.1rem;">Current build energy</h4>
+      <ul style="margin:0; padding-left:18px; color:#94a1b2; line-height:1.7;">
+        <li>Crafting design systems that sync Flutter motion with React experiences.</li>
+        <li>Scaling FastAPI gateways with thoughtful observability and testing.</li>
+        <li>Designing developer tooling that keeps cross-stack velocity smooth.</li>
+      </ul>
+    </div>
+    <div style="background:rgba(13,17,23,0.8); padding:22px 24px; border-radius:16px; border:1px solid rgba(148,161,178,0.14);">
+      <h4 style="margin:0 0 10px; color:#f8f9ff; font-size:1.1rem;">Always experimenting with</h4>
+      <ul style="margin:0; padding-left:18px; color:#94a1b2; line-height:1.7;">
+        <li>UI prototyping flows that layer storytelling on top of live data.</li>
+        <li>Edge-ready architectures that feel instant everywhere.</li>
+        <li>Developer experience rituals that keep teams shipping joyfully.</li>
+      </ul>
+    </div>
+  </div>
 </div>
 
 <br />
 
-<div align="center" style="max-width:780px; font-size:1.05rem; color:#94a1b2; line-height:1.65;">
+<div align="center" style="max-width:860px; margin:0 auto; font-family:'Inter',sans-serif; color:#94a1b2; line-height:1.7;">
   <p>
-    I obsess over meaningful UX flows, resilient API design, and the craft of developer experience. Whether it's pairing Flutter animations
-    with real-time FastAPI services or iterating on React-driven design systems, I'm chasing work that feels cohesive, thoughtful, and fun.
-  </p>
-  <p>
-    Beyond shipping features, I'm steadily documenting patterns, refining tooling, and learning from every stack I encounter. If there's a way
-    to make the build pipeline smoother or the interface kinder, I'm there for it.
+    My workflow is equal parts curiosity and craft: a sprinkle of system design, a dash of visual storytelling, and a lot of time spent polishing the small moments that make products memorable. If there's an opportunity to merge delightful UX with serious engineering rigor, I'm in.
   </p>
 </div>
 
 <br />
 
-<div align="center">
-  <a href="mailto:hello@amir.dev"><img src="https://img.shields.io/badge/Email-ff6b6b?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
-  <a href="https://linkedin.com/in/amir"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
-  <a href="https://github.com/amir"><img src="https://img.shields.io/badge/GitHub-161B22?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
+<div align="center" style="display:grid; gap:18px; max-width:860px; margin:0 auto;">
+  <img src="https://streak-stats.demolab.com?user=amir&theme=transparent&hide_border=true&dates=94a1b2&ring=7f5af0&fire=2cb6f6&currStreakLabel=f8f9ff" alt="GitHub streak" />
+  <img src="https://github-readme-activity-graph.vercel.app/graph?username=amir&bg_color=0d1117&color=7f5af0&line=2cb6f6&point=ffffff&area=true&hide_border=true" alt="Contribution graph" />
 </div>
 
 <br />
 
-<div align="center" style="font-size:0.9rem; color:#7f5af0;">
-  <em>"Code is just creative energy in motion." — Amir</em>
+<p align="center">
+  <img src="https://github.com/Platane/snk/raw/output/github-contribution-grid-snake-dark.svg" alt="Snake animation" />
+</p>
+
+<br />
+
+<div align="center" style="font-family:'Inter',sans-serif; color:#94a1b2;">
+  <p style="margin-bottom:16px;">
+    <a href="mailto:hello@amir.dev"><img src="https://img.shields.io/badge/Email-ff6b6b?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
+    <a href="https://linkedin.com/in/amir"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+    <a href="https://github.com/amir"><img src="https://img.shields.io/badge/GitHub-161B22?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
+  </p>
+  <em style="color:#7f5af0;">"Code is just creative energy in motion." — Amir</em>
 </div>
+
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:2cb6f6,100:7f5af0&height=120&section=footer" alt="footer" />
+</p>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:7f5af0,100:2cb6f6&height=220&section=header&text=Hey%2C%20I'm%20Amir&fontSize=54&fontColor=ffffff&fontAlign=50&fontAlignY=35&desc=Arch%20Linux%20user%20%7C%20Full-stack%20craftsman&descAlign=50&descAlignY=60" alt="Amir header" />
+  <img src="https://raw.githubusercontent.com/Anmol-Baranwal/Awesome-README-Templates/main/Assets/Gif/aurora.gif" alt="Aurora gradient animation" style="width:100%; max-width:960px; border-radius:28px;" />
 </p>
 
 <p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=22&pause=1400&color=7F5AF0&center=true&vCenter=true&width=600&lines=I+use+Arch%2C+btw.;Flutter+%2B+FastAPI+%2B+React+in+flow.;Restless+about+every+other+stack+too." alt="Typing intro" />
+  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=24&duration=3800&pause=1400&color=7F5AF0&center=true&vCenter=true&width=600&lines=Hey%2C+I'm+Amir.;I+use+Arch%2C+btw.;Flutter+%2B+FastAPI+%2B+React+in+flow.;Forever+curious+about+every+stack." alt="Typing intro" />
 </p>
 
 <p align="center" style="max-width:760px; margin: 0 auto; font-family:'Inter',sans-serif; color:#94a1b2; font-size:1.05rem; line-height:1.8;">
   I'm a product-minded engineer who keeps the pipeline elegant and the interface delightful. Whether I'm animating Flutter
   micro-interactions, crafting resilient FastAPI services, or steering React-driven systems, I care about the whole experience—
   from architecture to polish.
+</p>
+
+<p align="center" style="margin-top: 12px;">
+  <img src="https://img.shields.io/badge/Arch%20Linux-1793D1?style=for-the-badge&logo=archlinux&logoColor=white" alt="Arch Linux badge" />
 </p>
 
 <br />
@@ -84,7 +88,3 @@
   </p>
   <em style="color:#7f5af0;">"Code is just creative energy in motion." — Amir</em>
 </div>
-
-<p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:2cb6f6,100:7f5af0&height=120&section=footer" alt="footer" />
-</p>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# readme
+<div align="center">
+  <h1 style="font-size:3.5rem; font-weight:800; margin-bottom:0;">✨ Hey, I'm <span style="color:#7f5af0;">Amir</span></h1>
+  <p style="font-size:1.2rem; color:#94a1b2; margin-top:0.5rem;">
+    Full‑stack explorer crafting experiences across every layer — currently shipping with Flutter, FastAPI & React.
+  </p>
+  <img src="https://img.shields.io/badge/arch%20btw-0f172a?style=for-the-badge&logo=archlinux&logoColor=7dd3fc" alt="Arch BTW" />
+</div>
+
+---
+
+## 🌈 Tech Palette
+
+| Layer | Favourites | Vibe |
+| :--- | :--- | :--- |
+| Mobile Magic | <img src="https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter" /> | Smooth animations & pixel-perfect UIs |
+| Web Canvas | <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" /> | Component-driven storytelling |
+| API Wizardry | <img src="https://img.shields.io/badge/FastAPI-009688?style=for-the-badge&logo=fastapi&logoColor=white" alt="FastAPI" /> | Fast, clean, async-first backends |
+| ...and beyond | Every stack I can get my hands on | Infinite curiosity ✨ |
+
+---
+
+## 🧭 Current Focus
+
+- 🎯 Building hybrid apps that feel native everywhere.
+- ⚡️ Experimenting with real-time experiences & delightful micro-interactions.
+- 🛠️ Designing APIs that feel like products.
+- 🧪 Constantly iterating on developer experience — because great DX powers great UX.
+
+---
+
+## 📌 Featured Highlights
+
+> A snapshot of things that make me excited to open the editor.
+
+- **Flow-first architecture** – Orchestrating frontends with state machines for clarity and resilience.
+- **Design systems nerd** – Crafting reusable component libraries, accessible color palettes, and motion guides.
+- **Cloud-native mindset** – Deploying with confidence using containerized, automated pipelines.
+
+---
+
+## ☕ Let's Connect
+
+<div align="center">
+  <a href="mailto:hello@amir.dev"><img src="https://img.shields.io/badge/Email-ff6b6b?style=for-the-badge&logo=gmail&logoColor=white" alt="Email" /></a>
+  <a href="https://linkedin.com/in/amir"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
+  <a href="https://github.com/amir"><img src="https://img.shields.io/badge/GitHub-161B22?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" /></a>
+</div>
+
+---
+
+<sub align="center">“Code is just creative energy in motion.” — Amir</sub>


### PR DESCRIPTION
## Summary
- redesign README with a modern hero section and curated highlights
- showcase current focus on Flutter, FastAPI, React, and general full-stack exploration
- add visually engaging badges and contact links while noting Arch Linux usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4e5ceb64832f96cc1598217995c6