### PR TITLE
Refresh README with modern crowded layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,126 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/Anmol-Baranwal/Awesome-README-Templates/main/Assets/Gif/aurora.gif" alt="Aurora gradient animation" style="width:100%; max-width:960px; border-radius:28px;" />
-</p>
+<article align="center" style="font-family:'Inter',sans-serif; color:#f8f9ff; background:radial-gradient(circle at top,#1f2233 0%,#0d1117 55%,#07090f 100%); padding:48px 18px 72px; border-radius:28px; border:1px solid rgba(148,161,178,0.15); box-shadow:0 24px 60px -30px rgba(127,90,240,0.75); max-width:1080px; margin:32px auto;">
 
-<p align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=24&duration=3800&pause=1400&color=7F5AF0&center=true&vCenter=true&width=600&lines=Hey%2C+I'm+Amir.;I+use+Arch%2C+btw.;Flutter+%2B+FastAPI+%2B+React+in+flow.;Forever+curious+about+every+stack." alt="Typing intro" />
-</p>
-
-<p align="center" style="max-width:760px; margin: 0 auto; font-family:'Inter',sans-serif; color:#94a1b2; font-size:1.05rem; line-height:1.8;">
-  I'm a product-minded engineer who keeps the pipeline elegant and the interface delightful. Whether I'm animating Flutter
-  micro-interactions, crafting resilient FastAPI services, or steering React-driven systems, I care about the whole experience—
-  from architecture to polish.
-</p>
-
-<p align="center" style="margin-top: 12px;">
-  <img src="https://img.shields.io/badge/Arch%20Linux-1793D1?style=for-the-badge&logo=archlinux&logoColor=white" alt="Arch Linux badge" />
-</p>
-
-<br />
-
-<div align="center" style="display:grid; gap:16px; max-width:860px; margin:0 auto;">
-  <img src="https://github-readme-stats.vercel.app/api?username=Amir-beigi-84&show_icons=true&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6&icon_color=2cb6f6" alt="GitHub stats" style="border-radius:18px;" />
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Amir-beigi-84&layout=compact&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6" alt="Top languages" style="border-radius:18px;" />
-  <img src="https://streak-stats.demolab.com?user=Amir-beigi-84&theme=transparent&hide_border=true&dates=94a1b2&ring=7f5af0&fire=2cb6f6&currStreakLabel=f8f9ff" alt="GitHub streak" style="border-radius:18px;" />
-</div>
-
-<br />
-
-<div align="center" style="max-width:860px; margin:0 auto; display:grid; gap:20px; font-family:'Inter',sans-serif;">
-  <div style="background:linear-gradient(135deg,rgba(127,90,240,0.16),rgba(44,182,246,0.12)); padding:26px 28px; border-radius:18px; border:1px solid rgba(148,161,178,0.15); backdrop-filter:blur(18px);">
-    <h3 style="margin:0 0 14px; color:#f8f9ff; font-size:1.4rem;">Stacks in heavy rotation</h3>
-    <p style="margin:0; color:#94a1b2; line-height:1.7;">
-      Flutter for buttery motion and native feel, FastAPI for confident, type-hinted services, React for immersive web apps.
-      I'm still sampling every stack I can get my hands on, but these three are on repeat right now.
-    </p>
-    <p style="margin:16px 0 0;">
-      <img src="https://skillicons.dev/icons?i=flutter,fastapi,react,ts,python,dart" alt="Tech icons" />
-    </p>
-  </div>
-
-  <div style="display:grid; gap:16px;">
-    <div style="background:rgba(13,17,23,0.8); padding:22px 24px; border-radius:16px; border:1px solid rgba(148,161,178,0.14);">
-      <h4 style="margin:0 0 10px; color:#f8f9ff; font-size:1.1rem;">Current build energy</h4>
-      <ul style="margin:0; padding-left:18px; color:#94a1b2; line-height:1.7;">
-        <li>Crafting design systems that sync Flutter motion with React experiences.</li>
-        <li>Scaling FastAPI gateways with thoughtful observability and testing.</li>
-        <li>Designing developer tooling that keeps cross-stack velocity smooth.</li>
-      </ul>
+  <header style="display:grid; gap:22px;">
+    <div style="display:flex; flex-wrap:wrap; align-items:center; justify-content:center; gap:16px;">
+      <img src="https://raw.githubusercontent.com/Anmol-Baranwal/Awesome-README-Templates/main/Assets/Gif/aurora.gif" alt="Aurora gradient animation" style="width:100%; max-width:920px; border-radius:22px; border:1px solid rgba(148,161,178,0.18);" />
+      <img src="https://komarev.com/ghpvc/?username=Amir-beigi-84&label=Profile+views&color=7f5af0&style=for-the-badge" alt="Profile views badge" />
+      <img src="https://img.shields.io/badge/Arch%20Linux-1793D1?style=for-the-badge&logo=archlinux&logoColor=white" alt="Arch Linux badge" />
+      <img src="https://img.shields.io/badge/Polyglot-React%20%E2%80%A2%20Flutter%20%E2%80%A2%20FastAPI-2cb6f6?style=for-the-badge" alt="Tech polyglot" />
     </div>
-    <div style="background:rgba(13,17,23,0.8); padding:22px 24px; border-radius:16px; border:1px solid rgba(148,161,178,0.14);">
-      <h4 style="margin:0 0 10px; color:#f8f9ff; font-size:1.1rem;">Always experimenting with</h4>
-      <ul style="margin:0; padding-left:18px; color:#94a1b2; line-height:1.7;">
-        <li>UI prototyping flows that layer storytelling on top of live data.</li>
-        <li>Edge-ready architectures that feel instant everywhere.</li>
-        <li>Developer experience rituals that keep teams shipping joyfully.</li>
-      </ul>
+
+    <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=26&duration=3600&pause=1200&color=7F5AF0&center=true&vCenter=true&width=720&lines=Hey%2C+I'm+Amir.;I+design+joyful+dev+experiences.;Flutter+%2B+FastAPI+%2B+React+in+flow.;Forever+curious+about+every+stack." alt="Typing intro" />
+
+    <p style="margin:0 auto; max-width:720px; line-height:1.85; color:#94a1b2; font-size:1.05rem;">
+      I’m a product-minded engineer blending motion-rich Flutter apps, fast FastAPI services, and expressive React experiences into cohesive systems. From architecture decisions to micro-interactions, I obsess over the pipeline feeling as refined as the interface looks.
+    </p>
+
+    <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin-top:8px;">
+      <a href="mailto:amirbeigicontact@gmail.com" style="text-decoration:none;">
+        <img src="https://img.shields.io/badge/Email-Amir%20Beigi-7f5af0?style=for-the-badge&logo=gmail&logoColor=white" alt="Email Amir Beigi" />
+      </a>
+      <a href="https://www.linkedin.com/in/amir-beigi-code/" target="_blank" rel="noreferrer" style="text-decoration:none;">
+        <img src="https://img.shields.io/badge/LinkedIn-Connect-2cb6f6?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn Amir Beigi" />
+      </a>
+      <a href="https://www.buymeacoffee.com/amirbeigi" target="_blank" rel="noreferrer" style="text-decoration:none;">
+        <img src="https://img.shields.io/badge/Support-Buy%20me%20a%20coffee-f97316?style=for-the-badge&logo=buymeacoffee&logoColor=white" alt="Support" />
+      </a>
+      <a href="https://portfolio-amirbeigi.vercel.app" target="_blank" rel="noreferrer" style="text-decoration:none;">
+        <img src="https://img.shields.io/badge/Portfolio-Live-22d3ee?style=for-the-badge&logo=vercel&logoColor=white" alt="Portfolio" />
+      </a>
     </div>
-  </div>
-</div>
+  </header>
 
-<br />
+  <section style="margin-top:48px; display:grid; gap:24px;">
+    <div style="display:grid; gap:18px; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); align-items:stretch;">
+      <div style="background:linear-gradient(145deg,rgba(127,90,240,0.28),rgba(13,17,23,0.7)); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Stacks on heavy rotation</h3>
+        <p style="margin:0 0 16px; color:#94a1b2; line-height:1.7;">
+          Flutter for buttery motion, FastAPI for type-safe velocity, React for expressive web canvases. Sprinkle in TypeScript, Python, and a taste for system design finesse.
+        </p>
+        <img src="https://skillicons.dev/icons?i=flutter,fastapi,react,ts,python,dart,postgres,docker,redis" alt="Tech icons" />
+      </div>
+      <div style="background:linear-gradient(145deg,rgba(44,182,246,0.24),rgba(13,17,23,0.7)); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Build energy right now</h3>
+        <ul style="margin:0; padding-left:20px; color:#94a1b2; line-height:1.7;">
+          <li>Designing multi-platform design systems with a single storytelling language.</li>
+          <li>Automating release pipelines with DX-first tooling and typed contracts.</li>
+          <li>Experimenting with spatial UI and realtime collaboration primitives.</li>
+        </ul>
+      </div>
+      <div style="background:linear-gradient(145deg,rgba(15,217,189,0.22),rgba(13,17,23,0.7)); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Always shipping with</h3>
+        <ul style="margin:0; padding-left:20px; color:#94a1b2; line-height:1.7;">
+          <li>Story-driven prototyping that keeps stakeholders in the loop.</li>
+          <li>Observability, testing, and docs interwoven with feature delivery.</li>
+          <li>Developer rituals that nudge teams toward flow-state shipping.</li>
+        </ul>
+      </div>
+    </div>
 
-<div align="center" style="max-width:900px; margin:0 auto; font-family:'Inter',sans-serif;">
-  <img src="https://github-readme-activity-graph.vercel.app/graph?username=Amir-beigi-84&bg_color=0d1117&color=7f5af0&line=2cb6f6&point=f8f9ff&area=true&hide_border=true" alt="Contribution graph" style="border-radius:18px;" />
-  <img src="https://raw.githubusercontent.com/Platane/snk/output/github-contribution-grid-snake-dark.svg" alt="GitHub contribution snake" style="border-radius:18px;" />
-</div>
+    <div style="display:grid; gap:18px;">
+      <h3 style="margin:0; font-size:1.4rem;">Signal boost</h3>
+      <div style="display:grid; gap:18px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); align-items:stretch;">
+        <img src="https://github-readme-stats.vercel.app/api?username=Amir-beigi-84&show_icons=true&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6&icon_color=2cb6f6" alt="GitHub stats" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+        <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=Amir-beigi-84&layout=compact&hide_border=true&bg_color=0d1117&title_color=7f5af0&text_color=ccd6f6" alt="Top languages" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+        <img src="https://streak-stats.demolab.com?user=Amir-beigi-84&theme=transparent&hide_border=true&dates=94a1b2&ring=7f5af0&fire=2cb6f6&currStreakLabel=f8f9ff" alt="GitHub streak" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+      </div>
+      <div style="display:grid; gap:18px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); align-items:stretch;">
+        <img src="https://github-profile-trophy.vercel.app/?username=Amir-beigi-84&theme=darkhub&no-frame=true&margin-w=10&margin-h=10" alt="GitHub profile trophies" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+        <img src="https://metrics.lecoq.io/Amir-beigi-84?template=classic&isocalendar=1&isocalendar.duration=full-year&achievements=1&achievements.threshold=C&notable=1&config.timezone=Asia%2FTehran" alt="Metrics dashboard" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+        <img src="https://github-contributor-stats.vercel.app/api?username=Amir-beigi-84&limit=5&theme=tokyonight&combine_all_yearly_contributions=true" alt="Contributor stats" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+      </div>
+    </div>
+
+    <div style="display:grid; gap:18px; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); align-items:stretch;">
+      <div style="background:rgba(13,17,23,0.88); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Now dashboard</h3>
+        <ul style="margin:0; padding-left:20px; color:#94a1b2; line-height:1.7;">
+          <li>Designing a realtime collaboration canvas with CRDT-backed sync.</li>
+          <li>Refining a FastAPI service mesh with distributed tracing.</li>
+          <li>Sketching a Flutter motion library for product-ready storytelling.</li>
+        </ul>
+      </div>
+      <div style="background:rgba(13,17,23,0.88); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Toolbox staples</h3>
+        <p style="margin:0; color:#94a1b2; line-height:1.7;">
+          VS Code remote, Neovim motions, Linear roadmaps, Supabase backend, Vercel deploys, GitHub Actions choreographing the whole show.
+        </p>
+        <p style="margin:16px 0 0;">
+          <img src="https://skillicons.dev/icons?i=vscode,neovim,vercel,supabase,githubactions,figma,linux" alt="Tool icons" />
+        </p>
+      </div>
+      <div style="background:rgba(13,17,23,0.88); border-radius:22px; padding:26px 28px; border:1px solid rgba(148,161,178,0.18); text-align:left;">
+        <h3 style="margin:0 0 14px; font-size:1.35rem;">Community love</h3>
+        <p style="margin:0 0 16px; color:#94a1b2; line-height:1.7;">
+          Always down to jam on DX, product systems, and how to keep teams shipping joyfully. Hit me up and let’s build something magnetic.
+        </p>
+        <div style="display:flex; flex-wrap:wrap; gap:10px;">
+          <a href="mailto:amirbeigicontact@gmail.com" style="text-decoration:none;">
+            <img src="https://img.shields.io/badge/Say%20hi-email-7f5af0?style=flat&logo=gmail&logoColor=white" alt="Say hi" />
+          </a>
+          <a href="https://www.linkedin.com/in/amir-beigi-code/" target="_blank" rel="noreferrer" style="text-decoration:none;">
+            <img src="https://img.shields.io/badge/LinkedIn-message-2cb6f6?style=flat&logo=linkedin&logoColor=white" alt="LinkedIn message" />
+          </a>
+          <a href="https://twitter.com/search?q=Amir%20Beigi" target="_blank" rel="noreferrer" style="text-decoration:none;">
+            <img src="https://img.shields.io/badge/Twitter-follow-0ea5e9?style=flat&logo=twitter&logoColor=white" alt="Twitter follow" />
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section style="margin-top:48px; display:grid; gap:24px;">
+    <h3 style="margin:0; font-size:1.4rem;">Activity galaxy</h3>
+    <div style="display:grid; gap:18px;">
+      <img src="https://github-readme-activity-graph.vercel.app/graph?username=Amir-beigi-84&bg_color=0d1117&color=7f5af0&line=2cb6f6&point=f8f9ff&area=true&hide_border=true" alt="Contribution graph" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+      <img src="https://raw.githubusercontent.com/Platane/snk/output/github-contribution-grid-snake-dark.svg" alt="GitHub contribution snake" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+      <img src="https://github.com/ashutosh00710/github-readme-activity-graph/raw/output/github-contribution-grid-snake.svg" alt="Contribution snake alt" style="border-radius:18px; border:1px solid rgba(148,161,178,0.18);" />
+    </div>
+  </section>
+
+  <footer style="margin-top:60px; display:grid; gap:12px;">
+    <p style="margin:0; color:#94a1b2; font-size:0.95rem;">Made with Arch love, JetBrains Mono, and a healthy curiosity about the next stack.</p>
+    <p style="margin:0; color:#7f5af0; font-weight:600;">Let’s collaborate → <a href="mailto:amirbeigicontact@gmail.com" style="color:#2cb6f6; text-decoration:none;">amirbeigicontact@gmail.com</a></p>
+  </footer>
+
+</article>


### PR DESCRIPTION
## Summary
- rebuild the README hero with gradient styling, badge widgets, and clear contact buttons for email and LinkedIn
- expand the body with stacked cards that highlight focus areas, toolchains, and new widgets like trophies, metrics, and contributor stats
- enrich the activity section with multiple contribution visualizers to create a denser, more engaging profile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5f61fb20832faca1e1ac469462f3